### PR TITLE
Fix v6 watch API documentation

### DIFF
--- a/src/components/v6/ApiWatchV6.tsx
+++ b/src/components/v6/ApiWatchV6.tsx
@@ -1,13 +1,13 @@
 import * as React from "react"
 import CodeArea from "../CodeArea"
-import watchCode from "../codeExamples/watchCode"
-import watchCodeTs from "../codeExamples/watchCodeTs"
-import watchCodeTypes from "../codeExamples/watchCodeTypes"
+import watchCode from "../codeExamples/v6/watchCode"
+import watchCodeTs from "../codeExamples/v6/watchCodeTs"
+import watchCodeTypes from "../codeExamples/v6/watchCodeTypes"
 import generic from "../../data/generic"
 import * as typographyStyles from "../../styles/typography.module.css"
 import * as tableStyles from "../../styles/table.module.css"
 import TabGroup from "../TabGroup"
-import watchFieldArrayCode from "../codeExamples/watchFieldArrayCode"
+import watchFieldArrayCode from "../codeExamples/v6/watchFieldArrayCode"
 
 export default function ApiWatch({
   currentLanguage,


### PR DESCRIPTION
The v6 documentation currently shows an example for a callback version of `watch`, which is only available in v7:

```
  // Callback version of watch.  It's your responsibility to unsubscribe when done.
  React.useEffect(() => {
    const subscription = watch((value, { name, type }) => console.log(value, name, type));
    return () => subscription.unsubscribe();
  }, [watch]);
```

This seems to have happened because the imports for the code examples point to the latest examples directory, rather than the `v6/` directory.

The same issue was mentioned by another user [here](https://github.com/react-hook-form/react-hook-form/issues/1905#issuecomment-928716607)